### PR TITLE
Adding helper function to pull version info from relations.

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -52,3 +52,7 @@ class MongoDBClient(RelationBase):
             if all(data.values()):
                 connection_strings.append(str.format('{hostname}:{port}', **data))
         return connection_strings
+
+    def versions(self):
+        return [conv.get_remote('version', default=None)
+                for conv in self.conversations()]


### PR DESCRIPTION
mongodb-charm now provides a new "version" field, providing the installed version of MongoDB to clients.  (https://code.launchpad.net/~vultaire/mongodb-charm/+git/mongodb-charm/+merge/373023)

I'd like to be able to pull this information via the mongodb interface.